### PR TITLE
Avoid collusions in sample results due to milliseconds precision.

### DIFF
--- a/src/main/java/rocks/nt/apm/jmeter/JMeterInfluxDBBackendListenerClient.java
+++ b/src/main/java/rocks/nt/apm/jmeter/JMeterInfluxDBBackendListenerClient.java
@@ -102,6 +102,7 @@ public class JMeterInfluxDBBackendListenerClient extends AbstractBackendListener
 				Point point = Point.measurement(RequestMeasurement.MEASUREMENT_NAME).time(System.currentTimeMillis() * ONE_MS_IN_NANOSECONDS + getUniqueNumberForTheSamplerThread(), TimeUnit.NANOSECONDS)
 						.tag(RequestMeasurement.Tags.REQUEST_NAME, sampleResult.getSampleLabel()).addField(RequestMeasurement.Fields.ERROR_COUNT, sampleResult.getErrorCount())
 						.addField(RequestMeasurement.Fields.THREAD_NAME, sampleResult.getThreadName())
+						.addField(RequestMeasurement.Fields.TEST_NAME, testName)
 						.addField(RequestMeasurement.Fields.RESPONSE_TIME, sampleResult.getTime()).build();
 				influxDB.write(influxDBConfig.getInfluxDatabase(), influxDBConfig.getInfluxRetentionPolicy(), point);
 			}

--- a/src/main/java/rocks/nt/apm/jmeter/config/influxdb/RequestMeasurement.java
+++ b/src/main/java/rocks/nt/apm/jmeter/config/influxdb/RequestMeasurement.java
@@ -42,5 +42,10 @@ public interface RequestMeasurement {
 		 * Error count field.
 		 */
 		String ERROR_COUNT = "errorCount";
+
+		/**
+		 * Thread name field
+		 */
+		String THREAD_NAME = "threadName";
 	}
 }

--- a/src/main/java/rocks/nt/apm/jmeter/config/influxdb/RequestMeasurement.java
+++ b/src/main/java/rocks/nt/apm/jmeter/config/influxdb/RequestMeasurement.java
@@ -47,5 +47,10 @@ public interface RequestMeasurement {
 		 * Thread name field
 		 */
 		String THREAD_NAME = "threadName";
+
+		/**
+		 * Test name field
+		 */
+		String TEST_NAME = "testName";
 	}
 }


### PR DESCRIPTION
SampleResults happening at the very same millisecond are overriden in InfluxDB side because there is no distinguising parameters for the InfluxDB to add a new point instead of overriding the original.

This fix (yes I know it is a bit kluggy) attempt to fix this issue by

- Adding threadName field to the data point (so as to avoid different threads’ SampleResult to override each other)
- Adding (imaginary) nanoseconds part to the time so that events happening in the very same millisecond in the same thread not overriden.