### PR TITLE
Add nodeName configuration parameter and fill measurements with it.

### DIFF
--- a/src/main/java/rocks/nt/apm/jmeter/config/influxdb/RequestMeasurement.java
+++ b/src/main/java/rocks/nt/apm/jmeter/config/influxdb/RequestMeasurement.java
@@ -42,5 +42,10 @@ public interface RequestMeasurement {
 		 * Error count field.
 		 */
 		String ERROR_COUNT = "errorCount";
+
+		/**
+		 * Node name field
+		 */
+		String NODE_NAME = "nodeName";
 	}
 }

--- a/src/main/java/rocks/nt/apm/jmeter/config/influxdb/TestStartEndMeasurement.java
+++ b/src/main/java/rocks/nt/apm/jmeter/config/influxdb/TestStartEndMeasurement.java
@@ -37,6 +37,11 @@ public interface TestStartEndMeasurement {
 		 * Test name field.
 		 */
 		String TEST_NAME = "testName";
+
+		/**
+		 * Node name field
+		 */
+		String NODE_NAME = "nodeName";
 	}
 	
 	/**

--- a/src/main/java/rocks/nt/apm/jmeter/config/influxdb/VirtualUsersMeasurement.java
+++ b/src/main/java/rocks/nt/apm/jmeter/config/influxdb/VirtualUsersMeasurement.java
@@ -43,5 +43,10 @@ public interface VirtualUsersMeasurement {
 		 * Finished threads field.
 		 */
 		String FINISHED_THREADS = "finishedThreads";
+
+		/**
+		 * Node name field.
+		 */
+		String NODE_NAME = "nodeName";
 	}
 }


### PR DESCRIPTION
This is to support running multiple JMeter nodes to create high volumes of traffic. Currently total number of active users overriden by competing nodes. This will also fix issues with overriding the samples happening in the same milliseconds in InfluxDB.