### PR TITLE
Issue #11 - Record Subsamples

### DIFF
--- a/src/main/java/rocks/nt/apm/jmeter/JMeterInfluxDBBackendListenerClient.java
+++ b/src/main/java/rocks/nt/apm/jmeter/JMeterInfluxDBBackendListenerClient.java
@@ -108,10 +108,6 @@ public class JMeterInfluxDBBackendListenerClient extends AbstractBackendListener
 	 * Processes sampler results.
 	 */
 	public void handleSampleResults(List<SampleResult> sampleResults, BackendListenerContext context) {
-
-		// Indicates whether to write sub sample records to the database
-		recordSubSamples = Boolean.parseBoolean(context.getParameter(KEY_RECORD_SUB_SAMPLES, "false"));
-
 		// Gather all the listeners
 		List<SampleResult> allSampleResults = new ArrayList<SampleResult>();
 		for (SampleResult sampleResult : sampleResults) {
@@ -180,8 +176,8 @@ public class JMeterInfluxDBBackendListenerClient extends AbstractBackendListener
 
 		scheduler.scheduleAtFixedRate(this, 1, 1, TimeUnit.SECONDS);
 
-		// By default don't record subsamples
-		recordSubSamples = false;
+		// Indicates whether to write sub sample records to the database
+		recordSubSamples = Boolean.parseBoolean(context.getParameter(KEY_RECORD_SUB_SAMPLES, "false"));
 	}
 
 	@Override

--- a/src/main/java/rocks/nt/apm/jmeter/JMeterInfluxDBBackendListenerClient.java
+++ b/src/main/java/rocks/nt/apm/jmeter/JMeterInfluxDBBackendListenerClient.java
@@ -1,5 +1,6 @@
 package rocks.nt.apm.jmeter;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -45,6 +46,7 @@ public class JMeterInfluxDBBackendListenerClient extends AbstractBackendListener
 	private static final String KEY_TEST_NAME = "testName";
 	private static final String KEY_NODE_NAME = "nodeName";
 	private static final String KEY_SAMPLERS_LIST = "samplersList";
+	private static final String KEY_RECORD_SUB_SAMPLES = "recordSubSamples";
 
 	/**
 	 * Constants.
@@ -101,12 +103,31 @@ public class JMeterInfluxDBBackendListenerClient extends AbstractBackendListener
 	 * Processes sampler results.
 	 */
 	public void handleSampleResults(List<SampleResult> sampleResults, BackendListenerContext context) {
-		for (SampleResult sampleResult : sampleResults) {
-			getUserMetrics().add(sampleResult);
 
-			if ((null != regexForSamplerList && sampleResult.getSampleLabel().matches(regexForSamplerList)) || samplersToFilter.contains(sampleResult.getSampleLabel())) {
-				Point point = Point.measurement(RequestMeasurement.MEASUREMENT_NAME).time(System.currentTimeMillis() * ONE_MS_IN_NANOSECONDS + getUniqueNumberForTheSamplerThread(), TimeUnit.NANOSECONDS)
-						.tag(RequestMeasurement.Tags.REQUEST_NAME, sampleResult.getSampleLabel()).addField(RequestMeasurement.Fields.ERROR_COUNT, sampleResult.getErrorCount())
+		// Indicates whether to write sub sample records to the database
+		String recordSubSamples = context.getParameter(KEY_RECORD_SUB_SAMPLES, "");
+
+		// Gather all the listeners
+		List<SampleResult> allSampleResults = new ArrayList();
+		for (SampleResult sampleResult : sampleResults) {
+            allSampleResults.add(sampleResult);
+
+            if(null != recordSubSamples && recordSubSamples.equals("true")) {
+				for (SampleResult subResult : sampleResult.getSubResults()) {
+					allSampleResults.add(subResult);
+				}
+			}
+        }
+
+		for(SampleResult sampleResult: allSampleResults) {
+            getUserMetrics().add(sampleResult);
+
+			if ((null != regexForSamplerList && sampleResult.getSampleLabel().matches(regexForSamplerList)) ||
+					samplersToFilter.contains(sampleResult.getSampleLabel())) {
+				Point point = Point.measurement(RequestMeasurement.MEASUREMENT_NAME).time(
+						System.currentTimeMillis() * ONE_MS_IN_NANOSECONDS + getUniqueNumberForTheSamplerThread(), TimeUnit.NANOSECONDS)
+						.tag(RequestMeasurement.Tags.REQUEST_NAME, sampleResult.getSampleLabel()).addField(
+								RequestMeasurement.Fields.ERROR_COUNT, sampleResult.getErrorCount())
 						.addField(RequestMeasurement.Fields.THREAD_NAME, sampleResult.getThreadName())
 						.addField(RequestMeasurement.Fields.TEST_NAME, testName)
 						.addField(RequestMeasurement.Fields.NODE_NAME, nodeName)
@@ -123,12 +144,13 @@ public class JMeterInfluxDBBackendListenerClient extends AbstractBackendListener
 		arguments.addArgument(KEY_NODE_NAME, "Test-Node");
 		arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_HOST, "localhost");
 		arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_PORT, Integer.toString(InfluxDBConfig.DEFAULT_PORT));
-		arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_USER, "jmeter");
+		arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_USER, "");
 		arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_PASSWORD, "");
 		arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_DATABASE, InfluxDBConfig.DEFAULT_DATABASE);
 		arguments.addArgument(InfluxDBConfig.KEY_RETENTION_POLICY, InfluxDBConfig.DEFAULT_RETENTION_POLICY);
 		arguments.addArgument(KEY_SAMPLERS_LIST, ".*");
 		arguments.addArgument(KEY_USE_REGEX_FOR_SAMPLER_LIST, "true");
+		arguments.addArgument(KEY_RECORD_SUB_SAMPLES, "true");
 		return arguments;
 	}
 
@@ -190,7 +212,7 @@ public class JMeterInfluxDBBackendListenerClient extends AbstractBackendListener
 			ThreadCounts tc = JMeterContextService.getThreadCounts();
 			addVirtualUsersMetrics(getUserMetrics().getMinActiveThreads(), getUserMetrics().getMeanActiveThreads(), getUserMetrics().getMaxActiveThreads(), tc.startedThreads, tc.finishedThreads);
 		} catch (Exception e) {
-			LOGGER.error("Failed writing to influx", e);
+			LOGGER.error("Failed  to influx", e);
 		}
 	}
 


### PR DESCRIPTION
Issue 11 - Added ability to record sub samples. This controlled by the parameter 'recordSubSamples'. Also, made it optional to provide a Database User, the current code forces the 'jmeter' user, which can be a pain when running basic tests.